### PR TITLE
Fix service name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 screenshots/
 artefacts/
+/.idea/

--- a/JavaScript/01-no-tools.js
+++ b/JavaScript/01-no-tools.js
@@ -14,7 +14,7 @@ function printSystem(s) {
     console.log(chalk.green(JSON.stringify(s, null, 2)));
 }
 async function run() {
-    // Set up AWS Bedrock client
+    // Set up Amazon Bedrock client
     const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
 
     try {
@@ -49,6 +49,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/02-tool-definition.js
+++ b/JavaScript/02-tool-definition.js
@@ -55,7 +55,7 @@ const webTools = [
 ];
 
 async function run() {
-    // Set up AWS Bedrock client
+    // Set up Amazon Bedrock client
     const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
 
     try {
@@ -93,6 +93,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/03-loop.js
+++ b/JavaScript/03-loop.js
@@ -55,7 +55,7 @@ const webTools = [
 ];
 
 async function run() {
-  // Set up AWS Bedrock client
+  // Set up Amazon Bedrock client
   const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
 
   try {
@@ -161,6 +161,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/04-invoke-tool.js
+++ b/JavaScript/04-invoke-tool.js
@@ -63,7 +63,7 @@ function takeScreenshot() {
 }
 
 async function run() {
-    // Set up AWS Bedrock client
+    // Set up Amazon Bedrock client
     const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
 
     try {
@@ -174,6 +174,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/05-headless-browser.js
+++ b/JavaScript/05-headless-browser.js
@@ -90,7 +90,7 @@ async function run() {
     const page = await browser.newPage();
 
     try {
-        // Set up AWS Bedrock client
+        // Set up Amazon Bedrock client
         const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
         const messages = [
             {
@@ -209,6 +209,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/06-human-in-the-loop.js
+++ b/JavaScript/06-human-in-the-loop.js
@@ -162,7 +162,7 @@ async function run() {
     const page = await browser.newPage();
 
     try {
-        // Set up AWS Bedrock client
+        // Set up Amazon Bedrock client
         const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
         const messages = [
             {
@@ -291,6 +291,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/07-vision.js
+++ b/JavaScript/07-vision.js
@@ -196,7 +196,7 @@ async function run() {
     const page = await browser.newPage();
 
     try {
-    // Set up AWS Bedrock client
+    // Set up Amazon Bedrock client
     const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
         const messages = [
             {
@@ -375,6 +375,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/08-type-scroll-tools.js
+++ b/JavaScript/08-type-scroll-tools.js
@@ -237,7 +237,7 @@ async function run() {
     const page = await browser.newPage();
 
     try {
-        // Set up AWS Bedrock client
+        // Set up Amazon Bedrock client
         const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
         const messages = [
             {
@@ -428,6 +428,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/JavaScript/09-write-file.js
+++ b/JavaScript/09-write-file.js
@@ -280,7 +280,7 @@ async function run() {
     const page = await browser.newPage();
 
     try {
-        // Set up AWS Bedrock client
+        // Set up Amazon Bedrock client
         const bedrockClient = new BedrockRuntimeClient({ region: "us-west-2" });
         const messages = [
             {
@@ -481,6 +481,6 @@ async function run() {
 }
 
 // Main entry point
-printSystem("AWS Bedrock Web Tools Minimal Example")
-printSystem("------------------------------------")
+printSystem("Amazon Bedrock Web Tools Minimal Example")
+printSystem("----------------------------------------")
 run();

--- a/Python/01-no-tools.py
+++ b/Python/01-no-tools.py
@@ -21,7 +21,7 @@ def print_system(s: str):
     print(GREEN + s + RESET)
 
 async def run_example():
-    # Set up AWS Bedrock client
+    # Set up Amazon Bedrock client
     bedrock_client = boto3.client('bedrock-runtime')
     
     messages = [{
@@ -44,6 +44,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/02-tool-definition.py
+++ b/Python/02-tool-definition.py
@@ -52,7 +52,7 @@ web_tools = [
 ]
 
 async def run_example():
-    # Set up AWS Bedrock client
+    # Set up Amazon Bedrock client
     bedrock_client = boto3.client('bedrock-runtime')
     
     messages = [{
@@ -76,6 +76,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/03-loop.py
+++ b/Python/03-loop.py
@@ -68,7 +68,7 @@ web_tools = [
 ]
 
 async def run_example():
-    # Set up AWS Bedrock client
+    # Set up Amazon Bedrock client
     bedrock_client = boto3.client('bedrock-runtime')
     
     messages = [{
@@ -147,6 +147,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/04-invoke-tool.py
+++ b/Python/04-invoke-tool.py
@@ -78,7 +78,7 @@ async def take_screenshot():
     return {"filename": filename}
 
 async def run_example():
-    # Set up AWS Bedrock client
+    # Set up Amazon Bedrock client
     bedrock_client = boto3.client('bedrock-runtime')
     
     messages = [{
@@ -164,6 +164,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/05-headless-browser.py
+++ b/Python/05-headless-browser.py
@@ -103,7 +103,7 @@ async def run_example():
     page = await browser.new_page()
     
     try:
-        # Set up AWS Bedrock client
+        # Set up Amazon Bedrock client
         bedrock_client = boto3.client('bedrock-runtime')
         
         messages = [{
@@ -202,6 +202,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/06-human-in-loop.py
+++ b/Python/06-human-in-loop.py
@@ -133,7 +133,7 @@ async def run_example():
     page = await browser.new_page()
     
     try:
-        # Set up AWS Bedrock client
+        # Set up Amazon Bedrock client
         bedrock_client = boto3.client('bedrock-runtime')
         
         messages = [{
@@ -238,6 +238,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/07-vision.py
+++ b/Python/07-vision.py
@@ -162,7 +162,7 @@ async def run_example():
     page = await browser.new_page()
     
     try:
-        # Set up AWS Bedrock client
+        # Set up Amazon Bedrock client
         bedrock_client = boto3.client('bedrock-runtime')
         
         messages = [{
@@ -307,6 +307,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/08-type-scroll-tools.py
+++ b/Python/08-type-scroll-tools.py
@@ -240,7 +240,7 @@ async def run_example():
     page = await browser.new_page()
     
     try:
-        # Set up AWS Bedrock client
+        # Set up Amazon Bedrock client
         bedrock_client = boto3.client('bedrock-runtime')
         
         messages = [{
@@ -407,6 +407,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/09-write-file.py
+++ b/Python/09-write-file.py
@@ -276,7 +276,7 @@ async def run_example():
     page = await browser.new_page()
     
     try:
-        # Set up AWS Bedrock client
+        # Set up Amazon Bedrock client
         bedrock_client = boto3.client('bedrock-runtime')
         
         messages = [{
@@ -454,6 +454,6 @@ async def run_example():
 
 # Main entry point
 if __name__ == "__main__":
-    print_system("AWS Bedrock Web Tools Minimal Example")
-    print_system("------------------------------------")
+    print_system("Amazon Bedrock Web Tools Minimal Example")
+    print_system("----------------------------------------")
     asyncio.run(run_example())

--- a/Python/10-mcp-client.py
+++ b/Python/10-mcp-client.py
@@ -25,7 +25,7 @@ After completing your search, use the write_file tool to save your findings in m
 Think step by step and take screenshots between each step to ensure you are doing what you think you are doing.
 """
 
-# AWS Bedrock model ID
+# Amazon Bedrock model ID
 MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 #MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 
@@ -209,7 +209,7 @@ async def run_client():
                 mcp_tools = await session.list_tools()
                 print_system(f"Available MCP tools: {[tool.name for tool in mcp_tools.tools]}")
                 
-                # Set up AWS Bedrock client
+                # Set up Amazon Bedrock client
                 bedrock_client = boto3.client('bedrock-runtime')
                 
                 # Dynamically convert MCP tools to Bedrock format
@@ -359,6 +359,6 @@ if __name__ == "__main__":
     # Create directories for screenshots, artifacts, and downloads
     os.makedirs("downloads", exist_ok=True)
     
-    print_system("AWS Bedrock Web Tools with MCP Integration")
-    print_system("------------------------------------------")
+    print_system("Amazon Bedrock Web Tools with MCP Integration")
+    print_system("---------------------------------------------")
     asyncio.run(run_client())

--- a/Python/11-mcp-client.py
+++ b/Python/11-mcp-client.py
@@ -26,7 +26,7 @@ After completing your search, use the write_file tool to save your findings in m
 Think step by step and take screenshots between each step to ensure you are doing what you think you are doing.
 """
 
-# AWS Bedrock model ID
+# Amazon Bedrock model ID
 MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 # Model ID for summarization (using a smaller model for efficiency)
 SUMMARY_MODEL_ID = "us.amazon.nova-micro-v1:0"#"us.anthropic.claude-3-5-haiku-20241022-v1:0"
@@ -132,7 +132,7 @@ async def summarize_conversation(messages: List[Dict[str, Any]], bedrock_client)
     
     Args:
         messages: List of conversation messages
-        bedrock_client: AWS Bedrock client for calling the summarization model
+        bedrock_client: Amazon Bedrock client for calling the summarization model
         
     Returns:
         List of messages with middle part summarized
@@ -444,7 +444,7 @@ async def run_client():
                 mcp_tools = await session.list_tools()
                 print(f"Available MCP tools: {[tool.name for tool in mcp_tools.tools]}")
                 
-                # Set up AWS Bedrock client
+                # Set up Amazon Bedrock client
                 bedrock_client = boto3.client('bedrock-runtime')
                 
                 # Dynamically convert MCP tools to Bedrock format
@@ -609,6 +609,6 @@ if __name__ == "__main__":
     # Create directories for screenshots, artifacts, and downloads
     os.makedirs("downloads", exist_ok=True)
     
-    print("AWS Bedrock Web Tools with MCP Integration")
-    print("------------------------------------------")
+    print("Amazon Bedrock Web Tools with MCP Integration")
+    print("---------------------------------------------")
     asyncio.run(run_client())

--- a/Python/threat-model-analysis.md
+++ b/Python/threat-model-analysis.md
@@ -1,16 +1,16 @@
-# AWS Bedrock Web Tools - Threat Model Analysis
+# Amazon Bedrock Web Tools - Threat Model Analysis
 
 ## Introduction
 
 ### Purpose
 
-This project demonstrates how to use AWS Bedrock with Anthropic Claude and Amazon Nova models to create a web automation assistant with tool use, human-in-the-loop interaction, and vision capabilities. The primary purpose is educational, allowing developers to understand how to integrate advanced language models with web automation capabilities.
+This project demonstrates how to use Amazon Bedrock with Anthropic Claude and Amazon Nova models to create a web automation assistant with tool use, human-in-the-loop interaction, and vision capabilities. The primary purpose is educational, allowing developers to understand how to integrate advanced language models with web automation capabilities.
 
 ### Project/Asset Overview
 
-The project is a series of progressive examples that demonstrate different web automation capabilities using AWS Bedrock. The major components include:
+The project is a series of progressive examples that demonstrate different web automation capabilities using Amazon Bedrock. The major components include:
 
-1. **AWS Bedrock Client**: Uses the Bedrock API to communicate with Claude and Nova models
+1. **Amazon Bedrock Client**: Uses the Bedrock API to communicate with Claude and Nova models
 2. **Playwright Browser**: Controls a headless Chromium browser for web automation
 3. **Web Interaction Tools**: Navigation, screenshots, clicking, text input, scrolling
 4. **File Management**: Writing results to markdown files
@@ -35,7 +35,7 @@ The project is built and deployed as a series of Python scripts that can be run 
 
 ### References
 
-- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
 - [Playwright Documentation](https://playwright.dev/python/docs/intro)
 - [Model Context Protocol](https://github.com/anthropics/anthropic-mcp)
 
@@ -46,7 +46,7 @@ The project is built and deployed as a series of Python scripts that can be run 
 ```mermaid
 flowchart TB
     subgraph "AWS Cloud"
-        Bedrock["AWS Bedrock\nClaude/Nova Models"]
+        Bedrock["Amazon Bedrock\nClaude/Nova Models"]
     end
     
     subgraph "Local Environment"
@@ -65,7 +65,7 @@ flowchart TB
     User["User"] <--> Client
 ```
 
-The architecture consists of a Python client that communicates with AWS Bedrock models (Claude and Nova) using the boto3 library. The client also interacts with an MCP (Model Context Protocol) server that controls a headless browser using Playwright. The browser can navigate websites, take screenshots, and interact with web elements. Results and screenshots are saved to the local file system.
+The architecture consists of a Python client that communicates with Amazon Bedrock models (Claude and Nova) using the boto3 library. The client also interacts with an MCP (Model Context Protocol) server that controls a headless browser using Playwright. The browser can navigate websites, take screenshots, and interact with web elements. Results and screenshots are saved to the local file system.
 
 ### Data Flow Diagrams
 
@@ -73,7 +73,7 @@ The architecture consists of a Python client that communicates with AWS Bedrock 
 sequenceDiagram
     participant User
     participant Client as Python Client
-    participant Bedrock as AWS Bedrock
+    participant Bedrock as Amazon Bedrock
     participant MCP as MCP Server
     participant Browser as Playwright Browser
     participant FileSystem as File System
@@ -127,7 +127,7 @@ sequenceDiagram
 
 | Asset Name | Asset Usage | Data Type | Comments |
 |------------|-------------|-----------|----------|
-| AWS Credentials | Used to authenticate with AWS Bedrock | Credentials | Stored in local AWS configuration |
+| AWS Credentials | Used to authenticate with Amazon Bedrock | Credentials | Stored in local AWS configuration |
 | Screenshots | Visual captures of web pages | Media | Stored in local filesystem with random UUIDs |
 | Generated markdown files | Documentation of search results | Content | Stored in local filesystem |
 | Browser session | Temporary browser instance for web automation | Session | Automatically cleaned up after execution |
@@ -148,7 +148,7 @@ sequenceDiagram
 
 | Threat # | Priority | Threat | STRIDE | Affected Assets | Mitigations | Decision | Status/Notes |
 |----------|----------|--------|--------|----------------|-------------|----------|--------------|
-| T-001 | High | A threat actor from the internet (TA1) could intercept API calls to AWS Bedrock, leading to exposure of prompts and responses | Information Disclosure | AWS Credentials, Conversation history | M-001 | Mitigate | Implemented |
+| T-001 | High | A threat actor from the internet (TA1) could intercept API calls to Amazon Bedrock, leading to exposure of prompts and responses | Information Disclosure | AWS Credentials, Conversation history | M-001 | Mitigate | Implemented |
 | T-002 | Medium | A threat actor with local file system access (TA2) could access generated files and screenshots | Information Disclosure | Screenshots, Generated markdown files | M-002 | Accept | Partially implemented |
 | T-003 | High | A threat actor with AWS credential access (TA3) could use the credentials to access AWS services | Elevation of Privilege | AWS Credentials | M-003 | Mitigate | Not explicitly implemented |
 | T-004 | Medium | A threat actor controlling websites (TA4) could execute malicious code in the browser context | Tampering, Information Disclosure | Browser session | M-004 | Mitigate | Implemented |
@@ -159,7 +159,7 @@ sequenceDiagram
 
 | Mitigation Number | Mitigation Description | Threats Mitigating | Status | Related BSC | Comments |
 |-------------------|------------------------|-------------------|--------|------------|----------|
-| M-001 | Use of TLS for all API calls to AWS Bedrock | T-001 | Implemented | | boto3 uses HTTPS by default for all AWS API calls |
+| M-001 | Use of TLS for all API calls to Amazon Bedrock | T-001 | Implemented | | boto3 uses HTTPS by default for all AWS API calls |
 | M-002 | Restrict file system access to the local user only | T-002 | Partially implemented | | Relies on OS file permissions, no explicit permission setting in code |
 | M-003 | Use of temporary credentials with minimal permissions | T-003 | Not explicitly implemented | | Code relies on default AWS credential provider chain |
 | M-004 | Browser runs in headless mode with restricted capabilities | T-004 | Implemented | | Playwright runs in headless mode by default |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AWS Bedrock Web Tools Example
+# Amazon Bedrock Web Tools Example
 
-This project demonstrates how to use AWS Bedrock with Anthropic Claude and Amazon Nova models to create a web automation assistant with tool use, human-in-the-loop interaction, and vision capabilities.
+This project demonstrates how to use Amazon Bedrock with Anthropic Claude and Amazon Nova models to create a web automation assistant with tool use, human-in-the-loop interaction, and vision capabilities.
 
 ## Setup Instructions
 
@@ -10,7 +10,7 @@ This project demonstrates how to use AWS Bedrock with Anthropic Claude and Amazo
 This project contains a series of progressive examples that demonstrate different capabilities:
 
 ### Step 1: Basic Setup (No Tools)
-`01-no-tools` - A minimal example that sends a request to Claude via AWS Bedrock without any tools.
+`01-no-tools` - A minimal example that sends a request to Claude via Amazon Bedrock without any tools.
 
 ### Step 2: Tool Definition
 `02-tool-definition` - Introduces tool definitions for web navigation and screenshots.
@@ -97,11 +97,11 @@ This diagram helps visualize the progression from a simple API call to a sophist
 9. **MCP Architecture**: Client-server architecture with standardized protocol (Step 10)
 10. **Conversation Management**: Efficient token usage through media removal and conversation summarization (Step 11)
 
-## AWS Bedrock Configuration
+## Amazon Bedrock Configuration
 
 This example assumes you have:
 1. AWS CLI configured with appropriate credentials
-2. Access to Claude 3 models through AWS Bedrock
+2. Access to Claude 3 models through Amazon Bedrock
 3. Appropriate permissions to use the Bedrock API
 
 ## Example Workflow

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support
 
-This document outlines the support resources available for the AWS Bedrock Web Tools Example project.
+This document outlines the support resources available for the Amazon Bedrock Web Tools Example project.
 
 ## Getting Help
 
@@ -38,10 +38,10 @@ This project is maintained by AWS and the community. While we strive to be respo
 
 ## Professional Support
 
-For professional support with AWS Bedrock or other AWS services, please refer to:
+For professional support with Amazon Bedrock or other AWS services, please refer to:
 
 - [AWS Support](https://aws.amazon.com/support/)
-- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
 - [AWS Developer Forums](https://forums.aws.amazon.com/)
 
 ## Contributing

--- a/components-overview.md
+++ b/components-overview.md
@@ -1,4 +1,4 @@
-# AWS Bedrock Web Tools - Components Overview
+# Amazon Bedrock Web Tools - Components Overview
 
 This document provides a simplified overview of the key components for each step in the project.
 


### PR DESCRIPTION
# Pull Request

## Description
This pull request replaces all instances of "AWS Bedrock" with the official service name, "Amazon Bedrock", in the documentation, code comments, and console output.

## Type of change
Please delete options that are not relevant.

- [x] Documentation update

## How Has This Been Tested?
Documentation only, no tests required

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)

## Additional context
Add any other context about the pull request here.